### PR TITLE
Add 2025 Club World Cup teams list

### DIFF
--- a/data/teams.csv
+++ b/data/teams.csv
@@ -1,1 +1,33 @@
-
+team,country
+Palmeiras,Brazil
+Porto,Portugal
+Al Ahly,Egypt
+Inter Miami,USA
+Paris Saint-Germain,France
+Atlético Madrid,Spain
+Botafogo,Brazil
+Seattle Sounders,USA
+Bayern Munich,Germany
+Auckland City,New Zealand
+Boca Juniors,Argentina
+Benfica,Portugal
+Flamengo,Brazil
+Espérance de Tunis,Tunisia
+Chelsea,England
+Los Angeles FC,USA
+River Plate,Argentina
+Urawa Red Diamonds,Japan
+Monterrey,Mexico
+Inter Milan,Italy
+Fluminense,Brazil
+Borussia Dortmund,Germany
+Ulsan HD,South Korea
+Mamelodi Sundowns,South Africa
+Manchester City,England
+Wydad AC,Morocco
+Al Ain,United Arab Emirates
+Juventus,Italy
+Real Madrid,Spain
+Al-Hilal,Saudi Arabia
+Pachuca,Mexico
+Red Bull Salzburg,Austria


### PR DESCRIPTION
## Summary
- populate `data/teams.csv` with the 32 clubs announced in June 2025

## Testing
- `Rscript scripts/cwc_pull.R` *(fails: R packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5330a98832cabb6941017a57405