### PR TITLE
Install worldfootballR from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,18 @@ Major activities and expected completion dates are:
 ## Dependencies
 
 - R (version 4.0 or later)
-- [worldfootballR](https://github.com/JaseZiv/worldfootballR)
+- [worldfootballR](https://github.com/JaseZiv/worldfootballR) (GitHub version)
+  - The script installs this development version automatically using
+    `remotes::install_github`.
 - Other common packages used in the script include `dplyr`, `purrr` and
   `readr`
 
 You can install the required packages from the R console with:
 
 ```r
-install.packages(c("worldfootballR", "dplyr", "purrr", "readr"))
+install.packages("remotes")
+remotes::install_github("JaseZiv/worldfootballR")
+install.packages(c("dplyr", "purrr", "readr"))
 ```
 
 ## Running the script

--- a/scripts/cwc_pull.R
+++ b/scripts/cwc_pull.R
@@ -7,13 +7,16 @@ required_pkgs <- c("worldfootballR", "dplyr", "purrr", "readr", "stringr", "lubr
 
 # Install or update required packages
 installed <- rownames(installed.packages())
+if (!"remotes" %in% installed) {
+  install.packages("remotes", repos = "https://cloud.r-project.org")
+}
 for (pkg in required_pkgs) {
   if (!pkg %in% installed) {
-    install.packages(pkg, repos = "https://cloud.r-project.org")
-  } else if (pkg == "worldfootballR") {
-    tryCatch({
+    if (pkg == "worldfootballR") {
+      remotes::install_github("JaseZiv/worldfootballR")
+    } else {
       install.packages(pkg, repos = "https://cloud.r-project.org")
-    }, error = function(e) message("Unable to update worldfootballR: ", e$message))
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- install worldfootballR from GitHub with `remotes::install_github`
- document GitHub installation in README

## Testing
- `Rscript --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b15f1e6cc832c94143dbe766dcc75