### PR TITLE
Update README for league_code usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ The script expects a `teams.csv` file inside the `data/` folder with at least
 the following columns:
 
 ```csv
-team,country
-Palmeiras,Brazil
-Porto,Portugal
+team,country,league_code
+Palmeiras,Brazil,Serie A Brazil
+Porto,Portugal,Primeira Liga
 ```
+
+The `league_code` value is used to build the FBref URL for each team.
 
 ## Aggiornamento automatico
 


### PR DESCRIPTION
## Summary
- document that `league_code` is required in `teams.csv`
- show all three columns in the example
- mention `league_code` is used to build FBref URLs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b1ae65354832c991f4a48432586b9