### PR TITLE
Update install docs for worldfootballR

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You can install the required packages from the R console with:
 
 ```r
 install.packages("remotes")
+# use the development version for the season_end_year argument
 remotes::install_github("JaseZiv/worldfootballR")
 install.packages(c("dplyr", "purrr", "readr"))
 ```


### PR DESCRIPTION
## Summary
- point README instructions at worldfootballR GitHub version

## Testing
- `Rscript --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1c4ecbac832c8c91a6458a575a8b