### PR TITLE
Fix fbref league codes

### DIFF
--- a/data/teams.csv
+++ b/data/teams.csv
@@ -1,33 +1,33 @@
 team,country,league_code
-Palmeiras,Brazil,Serie A Brazil
-Porto,Portugal,Primeira Liga
-Al Ahly,Egypt,Egyptian Premier League
-Inter Miami,USA,Major League Soccer
-Paris Saint-Germain,France,Ligue 1
-Atlético Madrid,Spain,La Liga
-Botafogo,Brazil,Serie A Brazil
-Seattle Sounders,USA,Major League Soccer
+Palmeiras,Brazil,Serie-A
+Porto,Portugal,Primeira-Liga
+Al Ahly,Egypt,Egyptian-Premier-League
+Inter Miami,USA,Major-League-Soccer
+Paris Saint-Germain,France,Ligue-1
+Atlético Madrid,Spain,La-Liga
+Botafogo,Brazil,Serie-A
+Seattle Sounders,USA,Major-League-Soccer
 Bayern Munich,Germany,Bundesliga
-Auckland City,New Zealand,New Zealand National League
-Boca Juniors,Argentina,Primera División
-Benfica,Portugal,Primeira Liga
-Flamengo,Brazil,Serie A Brazil
-Espérance de Tunis,Tunisia,Tunisian Ligue Professionnelle 1
-Chelsea,England,Premier League
-Los Angeles FC,USA,Major League Soccer
-River Plate,Argentina,Primera División
-Urawa Red Diamonds,Japan,J1 League
-Monterrey,Mexico,Liga MX
-Inter Milan,Italy,Serie A
-Fluminense,Brazil,Serie A Brazil
+Auckland City,New Zealand,New-Zealand-National-League
+Boca Juniors,Argentina,Primera-Division
+Benfica,Portugal,Primeira-Liga
+Flamengo,Brazil,Serie-A
+Espérance de Tunis,Tunisia,Tunisian-Ligue-Professionnelle-1
+Chelsea,England,Premier-League
+Los Angeles FC,USA,Major-League-Soccer
+River Plate,Argentina,Primera-Division
+Urawa Red Diamonds,Japan,J1-League
+Monterrey,Mexico,Liga-MX
+Inter Milan,Italy,Serie-A
+Fluminense,Brazil,Serie-A
 Borussia Dortmund,Germany,Bundesliga
-Ulsan HD,South Korea,K League 1
-Mamelodi Sundowns,South Africa,South African Premier Division
-Manchester City,England,Premier League
-Wydad AC,Morocco,Botola
-Al Ain,United Arab Emirates,UAE Pro League
-Juventus,Italy,Serie A
-Real Madrid,Spain,La Liga
-Al-Hilal,Saudi Arabia,Saudi Pro League
-Pachuca,Mexico,Liga MX
-Red Bull Salzburg,Austria,Austrian Bundesliga
+Ulsan HD,South Korea,K-League-1
+Mamelodi Sundowns,South Africa,Premier-Division
+Manchester City,England,Premier-League
+Wydad AC,Morocco,Botola-Pro
+Al Ain,United Arab Emirates,UAE-Pro-League
+Juventus,Italy,Serie-A
+Real Madrid,Spain,La-Liga
+Al-Hilal,Saudi Arabia,Saudi-Professional-League
+Pachuca,Mexico,Liga-MX
+Red Bull Salzburg,Austria,Austrian-Bundesliga


### PR DESCRIPTION
## Summary
- update `data/teams.csv` to use hyphenated `league_code` strings so `fb_league_urls()` can detect the proper URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b22093248832cbf282d0e94391b27